### PR TITLE
fix: remove silent

### DIFF
--- a/src/main/g8/src/main/scala/$package__packaged$/$name;format="Camel"$.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/$name;format="Camel"$.scala
@@ -12,5 +12,5 @@ object $name;format="Camel"$ extends App {
 
   // Run it like any simple app
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
-    Server.start(8090, app.silent).exitCode
+    Server.start(8090, app).exitCode
 }


### PR DESCRIPTION
ZIO-HTTP's v1.0.0.0-RC24 removes the `silent` operator from Http. This PR attempts to fix that in the g8 template.

**Release Notes for v1.0.0.0-RC24**: https://github.com/dream11/zio-http/releases/tag/v1.0.0.0-RC24