### PR TITLE
fix: g8 template for build.sbt

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
   )
   .settings(
     Docker / version          := version.value,
-    Compile / run / mainClass := Option("com.example.zhttpservice.ZhttpService"),
+    Compile / run / mainClass := Option("$package$.$name;format="word,cap"$"),
   )
 
 addCommandAlias("fmt", "scalafmt; Test / scalafmt; sFix;")


### PR DESCRIPTION
Main class is fixed value, as it fails for arbitrary values.

Fixed a bug that prevented starting with non-default values.

## What happened

```sh
$ sbt new dream11/zio-http.g8
[info] welcome to sbt 1.6.2 (Homebrew Java 11.0.15)
[info] loading global plugins from /home/vagrant/.sbt/1.0/plugins
[info] set current project to new (in build file:/tmp/sbt_4d337452/new/)

ZHTTP Bootstrap

name [ZHTTP Service]: zio-http-hello-world
organisation [com.example]: com.example.hogefuga
package [com.example.hogefuga.ziohttphelloworld]:
version [1.0.0]:
sbtVersion [1.6.1]:
scalaVersion [2.13.8]:
zioTestVersion [1.0.13]:
scalaFmtVersion [3.0.7]:
scalafixVersion [0.9.34]:
sbtNativePackager [1.9.7]:
sbtRevolverVersion [0.9.1]:
zhttpVersion [1.0.0.0-RC24]:
scalaFmtPluginVersion [2.4.6]:
organizeImportsVersion [0.6.0]:

Template applied in /home/vagrant/workspace/tmp/./zio-http-hello-world

$ sbt
sbt:zio-http-hello-world> reStart
[info] Application root not yet started
[info] Starting application root in the background ...
root Starting com.example.zhttpservice.ZhttpService.main()
[success] Total time: 0 s, completed May 4, 2022, 11:36:04 AM
root[ERROR] Error: Could not find or load main class com.example.zhttpservice.ZhttpService
root[ERROR] Caused by: java.lang.ClassNotFoundException: com.example.zhttpservice.ZhttpService
root ... finished with exit code 1
```

## Check

```sh
$ sbt new file:///home/vagrant/workspace/tmp/zio-http.g8
[info] welcome to sbt 1.6.2 (Homebrew Java 11.0.15)
[info] loading global plugins from /home/vagrant/.sbt/1.0/plugins
[info] set current project to new (in build file:/tmp/sbt_249bfc2f/new/)

ZHTTP Bootstrap

name [ZHTTP Service]: zio-http-hello-world
organisation [com.example]: com.example.hogefuga
package [com.example.hogefuga.ziohttphelloworld]:
version [1.0.0]:
sbtVersion [1.6.1]:
scalaVersion [2.13.8]:
zioTestVersion [1.0.13]:
scalaFmtVersion [3.0.7]:
scalafixVersion [0.9.34]:
sbtNativePackager [1.9.7]:
sbtRevolverVersion [0.9.1]:
zhttpVersion [1.0.0.0-RC24]:
scalaFmtPluginVersion [2.4.6]:
organizeImportsVersion [0.6.0]:

Template applied in /home/vagrant/workspace/tmp/./zio-http-hello-world

$ sbt
sbt:zio-http-hello-world> reStart
[info] Application root not yet started
[info] Starting application root in the background ...
root Starting com.example.hogefuga.ziohttphelloworld.Ziohttphelloworld.main()
[success] Total time: 0 s, completed May 4, 2022, 11:39:49 AM
root Server started on port: 8090
```
